### PR TITLE
Fix error handling in controller loop

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -109,6 +109,9 @@ func (c *Controller) processNextItem() bool {
 			c.queue.Forget(key)
 			utilruntime.HandleError(err)
 		}
+
+		// stop processing this item and move on to the next
+		return true
 	}
 
 	// if the item doesn't exist then it was deleted and we need to fire off the handler's


### PR DESCRIPTION
## Summary
- stop processing queue items when informer lookup fails

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ab039760548323b8c11f7173445b07