### PR TITLE
docs: fix typo in usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This is a response to https://github.com/kubernetes/kubernetes/issues/25908.
 kubectl apply -f manifest.yml
 ```
 
-1. Add the `pod.kubernetes.io/sidecars` annotation to your pods, with a comma-seperated list of sidecar container names.
+1. Add the `pod.kubernetes.io/sidecars` annotation to your pods, with a comma-separated list of sidecar container names.
 
 Example:
 


### PR DESCRIPTION
## Summary
- fix spelling of "comma-separated" in usage docs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ab05cbcb748323975cf7a568ff6429